### PR TITLE
Fix freezing when parse type

### DIFF
--- a/airflow_munchkin/block_generator/imports_statement_gather.py
+++ b/airflow_munchkin/block_generator/imports_statement_gather.py
@@ -29,6 +29,7 @@ class ImportGather(BlockVisitor):
             "Optional",
             "Tuple",
             "Dict",
+            "Set",
             "List",
             "Iterator",
             "Iterable",

--- a/tests/client_parser/docstring_parser/test_typehint_parser.py
+++ b/tests/client_parser/docstring_parser/test_typehint_parser.py
@@ -67,6 +67,23 @@ class TestTypeHintParser(unittest.TestCase):
             typehint_parser.parse_typehint("Union[Optional[dict]]"),
         )
 
+    def test_should_parse_deprecated_union_style(self):
+        self.assertEqual(
+            TypeBrick(
+                kind="Iterator",
+                indexes=[
+                    TypeBrick(
+                        kind="Union",
+                        indexes=[
+                            TypeBrick(kind="Dict", indexes=[]),
+                            TypeBrick(kind="Set", indexes=[]),
+                        ],
+                    )
+                ],
+            ),
+            typehint_parser.parse_typehint("iterator[dict|set]"),
+        )
+
     @parameterized.expand(
         [
             (TypeBrick(kind="str", indexes=[]), "str"),


### PR DESCRIPTION
Problem occurs during parsing `google.cloud.pubsub_v1.SubscriberClient`
Output (hangs on this line forever):
```
INFO:root:Parsing typehint: iterator[dict|google.cloud.pubsub_v1.proto.pubsub_pb2.StreamingPullRequest]
```
solves: https://github.com/PolideaInternal/airflow/issues/301
